### PR TITLE
feat: 구글 Oauth 로그인 & 회원가입 

### DIFF
--- a/src/main/java/TSM/demo/controller/LoginController.java
+++ b/src/main/java/TSM/demo/controller/LoginController.java
@@ -1,16 +1,14 @@
 package TSM.demo.controller;
 
 import TSM.demo.service.LoginService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/login/oauth2", produces = "application/json")
+@RequiredArgsConstructor
 public class LoginController {
-    LoginService loginService;
-
-    public LoginController(LoginService loginService) {
-        this.loginService = loginService;
-    }
+    private final LoginService loginService;
 
     @GetMapping("/code/{registrationId}")
     public void googleLogin(@RequestParam String code, @PathVariable String registrationId) {

--- a/src/main/java/TSM/demo/controller/LoginController.java
+++ b/src/main/java/TSM/demo/controller/LoginController.java
@@ -1,0 +1,19 @@
+package TSM.demo.controller;
+
+import TSM.demo.service.LoginService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/login/oauth2", produces = "application/json")
+public class LoginController {
+    LoginService loginService;
+
+    public LoginController(LoginService loginService) {
+        this.loginService = loginService;
+    }
+
+    @GetMapping("/code/{registrationId}")
+    public void googleLogin(@RequestParam String code, @PathVariable String registrationId) {
+        loginService.socialLogin(code, registrationId);
+    }
+}

--- a/src/main/java/TSM/demo/controller/UserController.java
+++ b/src/main/java/TSM/demo/controller/UserController.java
@@ -1,0 +1,30 @@
+package TSM.demo.controller;
+
+
+import TSM.demo.domain.User;
+import TSM.demo.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class UserController {
+    private final UserService userService;
+
+    //회원가입 페이지로 이동
+    @GetMapping("/signup")
+    public String SignupForm() {
+        return "auth/signup";
+    }
+
+    //회원가입 POST 요청
+    @PostMapping("/signup")
+    public String createUser(User user) {
+        userService.join(user);
+        return "redirect:/";
+    }
+}

--- a/src/main/java/TSM/demo/domain/User.java
+++ b/src/main/java/TSM/demo/domain/User.java
@@ -4,17 +4,18 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.Cascade;
 
 @Entity(name = "user")
 @Getter
+@Setter
 public class User {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     @NotNull
     private int id;
-
 
     @Column(name="email")
     @NotNull
@@ -57,8 +58,7 @@ public class User {
         this.access_token = access_token;
     }
 
-
-    public void setUserHealth(UserHealth userHealth) {
-        this.userHealth = userHealth;
-    }
+//    public void setUserHealth(UserHealth userHealth) {
+//        this.userHealth = userHealth;
+//    }
 }

--- a/src/main/java/TSM/demo/repository/UserRepository.java
+++ b/src/main/java/TSM/demo/repository/UserRepository.java
@@ -1,0 +1,30 @@
+package TSM.demo.repository;
+
+import TSM.demo.domain.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepository {
+    private final EntityManager em;
+    public void save(User user) {em.persist(user);}
+
+    public User findOne(int id) {
+        return em.find(User.class, id);
+    }
+
+    public List<User> findAll() {
+        return em.createQuery("select u from user u", User.class)
+                .getResultList();
+    }
+
+    public User findByName(String name) {
+        return em.createQuery("select u from user u where u.name = :name", User.class)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+}

--- a/src/main/java/TSM/demo/service/LoginService.java
+++ b/src/main/java/TSM/demo/service/LoginService.java
@@ -1,6 +1,8 @@
 package TSM.demo.service;
 
+import TSM.demo.repository.UserRepository;
 import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -9,14 +11,12 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Service
+@RequiredArgsConstructor
 public class LoginService {
 
     private final Environment env;
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public LoginService(Environment env) {
-        this.env = env;
-    }
     public void socialLogin(String code, String registrationId) {
         String accessToken = getAccessToken(code, registrationId);
         JsonNode userResourceNode = getUserResource(accessToken, registrationId);

--- a/src/main/java/TSM/demo/service/LoginService.java
+++ b/src/main/java/TSM/demo/service/LoginService.java
@@ -1,0 +1,66 @@
+package TSM.demo.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.core.env.Environment;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class LoginService {
+
+    private final Environment env;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public LoginService(Environment env) {
+        this.env = env;
+    }
+    public void socialLogin(String code, String registrationId) {
+        String accessToken = getAccessToken(code, registrationId);
+        JsonNode userResourceNode = getUserResource(accessToken, registrationId);
+        System.out.println("userResourceNode = " + userResourceNode);
+
+        String id = userResourceNode.get("id").asText();
+        String email = userResourceNode.get("email").asText();
+        String nickname = userResourceNode.get("name").asText();
+
+        System.out.println("accessToken = " + accessToken);
+        System.out.println("id = " + id);
+        System.out.println("email = " + email);
+        System.out.println("nickname = " + nickname);
+    }
+
+    private String getAccessToken(String authorizationCode, String registrationId) {
+        String clientId = env.getProperty("oauth2." + registrationId + ".client-id");
+        String clientSecret = env.getProperty("oauth2." + registrationId + ".client-secret");
+        String redirectUri = env.getProperty("oauth2." + registrationId + ".redirect-uri");
+        String tokenUri = env.getProperty("oauth2." + registrationId + ".token-uri");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", authorizationCode);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity entity = new HttpEntity(params, headers);
+
+        ResponseEntity<JsonNode> responseNode = restTemplate.exchange(tokenUri, HttpMethod.POST, entity, JsonNode.class);
+        JsonNode accessTokenNode = responseNode.getBody();
+        return accessTokenNode.get("access_token").asText();
+    }
+
+    private JsonNode getUserResource(String accessToken, String registrationId) {
+        String resourceUri = env.getProperty("oauth2."+registrationId+".resource-uri");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity entity = new HttpEntity(headers);
+        return restTemplate.exchange(resourceUri, HttpMethod.GET, entity, JsonNode.class).getBody();
+    }
+}

--- a/src/main/java/TSM/demo/service/UserService.java
+++ b/src/main/java/TSM/demo/service/UserService.java
@@ -1,0 +1,31 @@
+package TSM.demo.service;
+
+import TSM.demo.domain.User;
+import TSM.demo.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    //회원 가입
+    @Transactional
+    public int join(User user) {
+        userRepository.save(user);
+        return user.getId();
+    }
+
+    //회원 조회
+    public List<User> findMembers() {
+        return userRepository.findAll();
+    }
+
+    public User findOne(int userId) {
+        return userRepository.findOne(userId);
+    }
+}

--- a/src/test/java/TSM/demo/UserServiceTest.java
+++ b/src/test/java/TSM/demo/UserServiceTest.java
@@ -1,0 +1,37 @@
+package TSM.demo;
+
+import TSM.demo.domain.User;
+import TSM.demo.repository.UserRepository;
+import TSM.demo.service.UserService;
+import jakarta.persistence.EntityManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class UserServiceTest {
+    @Autowired EntityManager em;
+    @Autowired UserService userService;
+
+    @Autowired UserRepository userRepository;
+
+    @Test
+    public void 회원가입() throws Exception {
+        //given
+        User user=new User("naver@naver.com","+8210-000-0000",true,"김건대","XXXX");
+
+        //when
+        int saveId = userService.join(user);
+
+        //then
+        assertEquals(user, userRepository.findOne(saveId));
+        assertEquals(user, userRepository.findByName(user.getName()));
+    }
+}

--- a/src/test/java/TSM/demo/domain/UserTest.java
+++ b/src/test/java/TSM/demo/domain/UserTest.java
@@ -1,5 +1,7 @@
 package TSM.demo.domain;
 
+import TSM.demo.controller.LoginController;
+import TSM.demo.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -9,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -48,6 +51,13 @@ public class UserTest {
         System.out.println(pk);
         User findUser=em.find(User.class,pk);
         Assertions.assertThat(findUser.getName()).isEqualTo("김건대");
+    }
+
+    @Test
+    public void user_repository_test() {
+        User user=new User("naver@naver.com","+8210-000-0000",true,"김건대","XXXX");
+
+        
     }
 
     @Test


### PR DESCRIPTION
## 📝Issue: 구글 Oauth 로그인 & 회원가입 구현
 로그인 및 회원가입 구현
## 📝Description
- 구글 Oauth 로그인 구현에 필요한 로직을 LoginController와 LoginService에 포함하였습니다. 이를 통해 AccessToken을 받아오고 token을 통해서는 로그인 한 유저의 정보를 확인할 수 있습니다.
- 회원가입 구현을 위해 UserRepository, UserController, UserService가 추가되었습니다. 클라이언트에서 회원가입 요청을 할 때 날리는 parameter를 받아서 신규 회원정보를 저장 할 수 있도록 구현하였습니다.

## 📝ETC
- 구글 로그인 테스트 방법:
https://accounts.google.com/o/oauth2/auth?client_id=CLIENT_ID&redirect_uri=REDIRECT_URI&response_type=code&scope=https://www.googleapis.com/auth/userinfo.emailhttps://www.googleapis.com/auth/userinfo.profile

- CLIENT_ID와 REDIRECT_URI에는 해당하는 값을 주면 테스트 할 수 있습니다. (보안상의 이유로 공개할 수 없습니다.)

- 회원가입 POST 요청 url은 임시로 설정해두었습니다: localhost:8080/auth/signup